### PR TITLE
Add explanation to add component to components directory index.js

### DIFF
--- a/docs/platform/cookbook/integrations/jsonplaceholder.mdx
+++ b/docs/platform/cookbook/integrations/jsonplaceholder.mdx
@@ -360,7 +360,16 @@ This works in exactly the same way as our `TodoItem` component.
 
 We've done all the hard work, we now just need to use our components somewhere in our application.
 
-I'm going to add them to the homepage.
+To access our component in an standardised way we will first export it to the component root.
+
+**`client/src/components/index.js`**
+```
+...
+export * from './Todo';
+```
+
+Now that it is available from the components directory I'm going to add them to the homepage.
+
 
 **`client/src/pages/home/Home.js`**
 ```js


### PR DESCRIPTION
While following the guide I just sort of naturally ended up doing this, but then later I realized that the guide doesn't explicitly tells the user to do this.  In the text change I called it "component root" but perhaps there is a better term to describe the function of having all the components available from the components directory.