### PR TITLE
feature/DPS-125/docs-for-currency-and-minMaxAmounts-configuration

### DIFF
--- a/dpsg/docs/features/currencies.md
+++ b/dpsg/docs/features/currencies.md
@@ -1,0 +1,40 @@
+---
+id: currencies
+title: Currency Specific Config
+sidebar_label: Currency Specific Config
+---
+
+## Overview
+
+Each payment method can be enabled for only certain currencies. By default, a new payment method will be available for all currencies, but by selecting a subset of currencies, the payment method will only be shown when one of the specified currencies is selected.
+
+## How to configure currencies
+
+All payment method config can be done via our `dcloud` cli tool.
+When configuring a new payment method using `dcloud payments:method:configure`, a wizard is launched to guide you through the configuration process.
+The intitial steps before selecting the currencies are:
+1. Select an environment
+2. Select the configured payment provider
+3. Select the payment method
+4. Set the name of the custom payment method
+5. Select the countries for the payment method ([Location Specific Config](/docs/features/locations))
+
+Step 6 asks you to select the currencies for which this payment method should be enabled. Select `ANY` to enable it for all currencies, or select specific currencies by using the `arrow keys` and `space` to select/deselect.
+
+### Configuration Options
+
+Currencies should be passed as an array to each payment method on your environment.  
+
+`*` represents all currencies. If no currency data is passed the method will be enabled for all currencies (`*`).
+
+:::note Not all methods showing
+We allow filtering of methods based on currencies. At the same time we also pass the currency code to each payment provider. Meaning that some methods, whilst enabled in DPSG, may not be available from the provider itself.
+:::
+
+```json
+"currencies": [
+    "EUR",
+    "USD"
+  ],
+```
+In the example above the method is enabled for Euro and US Dollar only.

--- a/dpsg/docs/features/minMaxAmounts.md
+++ b/dpsg/docs/features/minMaxAmounts.md
@@ -1,0 +1,47 @@
+---
+id: minMaxAmounts
+title: Min/Max Amounts
+sidebar_label: Min/Max Amounts
+---
+
+## Overview
+
+Each payment method can be enabled for only certain order amounts. By default, a new payment method will be available for all order amounts, but by specifying minimum and/or maximum order amounts per currency, a payment method will only show when the order amount and currency match the specified boundaries.
+
+## How to configure min/max amounts
+
+All payment method config can be done via our `dcloud` cli tool.
+When configuring a new payment method using `dcloud payments:method:configure`, a wizard is launched to guide you through the configuration process.
+The intitial steps before selecting the currencies are:
+1. Select an environment
+2. Select the configured payment provider
+3. Select the payment method
+4. Set the name of the custom payment method
+5. Select the countries for the payment method ([Location Specific Config](/docs/features/locations))
+6. Select the currencies for the payment method ([Currency Specific Config](/docs/features/currencies))
+7. Configure the surcharges ([Surcharges](/docs/features/surcharges))
+
+Step 8 asks you whether you want to set min/max amount restrictions or not (configure by typing `y`). Next, select a currency from the list. You are then asked to specify the minimum amount, which can be skipped by hitting `Enter` or specified by filling in a number. The same should then be done for the maximum amount.
+After configuring one set of min/max amounts, you are presented with the option to do the same for other currencies as well.
+
+### Configuration Options
+
+Min/Max amounts should be passed as an array to each payment method on your environment. This allows you to configure min/max amounts per currency.
+
+`*` represents all currencies.
+
+```json
+"minMaxAmounts": [
+  {
+    "currency": "EUR",
+    "min": 10
+  },
+  {
+    "currency": "USD",
+    "min": 5,
+    "max": 500
+  }
+]
+```
+
+In the example above the payment method will only be available for orders with a total of more than €10. When US Dollar is the selected currency, the payment method will be available when the order total is between $5 and $500.

--- a/sidebarsDpsg.js
+++ b/sidebarsDpsg.js
@@ -11,8 +11,10 @@ module.exports = {
       'docs/getting-started/usage',
     ],
     Features: [
-      'docs/features/surcharges',
+      'docs/features/currencies',
       'docs/features/locations',
+      'docs/features/surcharges',
+      'docs/features/minMaxAmounts',
       'docs/features/sort',
     ],
     Integrations: [


### PR DESCRIPTION
 - feat: Added docs for the currencies and minMaxAmounts config of new payment methods
 - Coming from the GitLab docs, there was a section with "dcloud docs coming", so I specified how to configure it using dcloud. If you doubt that this is necessary, I will remove it.